### PR TITLE
Use state_set() and state_get() for job_scheduler_rebuild_all instead of config

### DIFF
--- a/config/job_scheduler.settings.json
+++ b/config/job_scheduler.settings.json
@@ -1,4 +1,3 @@
 {
-    "_config_name": "job_scheduler.settings",
-    "job_scheduler_rebuild_all": "TRUE"
+    "_config_name": "job_scheduler.settings"
 }

--- a/job_scheduler.install
+++ b/job_scheduler.install
@@ -10,9 +10,7 @@
  */
 function job_scheduler_uninstall() {
   db_query("DELETE FROM {variable} WHERE name LIKE :name", array(':name' => 'job_scheduler_class_%'));
-  $config = config('job_scheduler.settings');
-  $config->set('job_scheduler_rebuild_all', "");
-  $config->save();
+  state_del('job_scheduler_rebuild_all');
 }
 
 /**
@@ -126,4 +124,17 @@ function job_scheduler_update_1000() {
 
   // Delete variables.
   update_variable_del('job_scheduler_rebuild_all');
+}
+
+/**
+ * Use state rather than config for job_scheduler_rebuild_all.
+ */
+function job_scheduler_update_1001() {
+  $config = config('job_scheduler.settings');
+  $state = $config->get('job_scheduler_rebuild_all');
+  if ($state !== NULL) {
+    state_set('job_scheduler_rebuild_all', $state);
+  }
+  $config->clear('job_scheduler_rebuild_all');
+  $config->save();
 }

--- a/job_scheduler.module
+++ b/job_scheduler.module
@@ -30,26 +30,15 @@ function job_scheduler_info($name = NULL) {
 }
 
 /**
- * Implements hook_config_info().
- */
-function job_scheduler_config_info() {
-  $prefixes['job_scheduler.settings'] = array(
-    'label' => t('job_scheduler settings'),
-    'group' => t('Configuration'),
-  );
-  return $prefixes;
-}
-
-/**
  * Implements hook_cron().
  */
 function job_scheduler_cron() {
   // Reschedule all jobs if requested.
-  if (config_get('job_scheduler.settings', 'job_scheduler_rebuild_all')) {
+  if (state_get('job_scheduler_rebuild_all')) {
     foreach (job_scheduler_info() as $name => $info) {
       job_scheduler_rebuild_scheduler($name, $info);
     }
-    config_set('job_scheduler.settings', 'job_scheduler_rebuild_all', FALSE);
+    state_set('job_scheduler_rebuild_all', FALSE);
     return;
   }
 
@@ -121,7 +110,7 @@ function job_scheduler_modules_disabled($modules) {
  * @todo What should we do about missing ones when disabling their module?
  */
 function job_scheduler_rebuild_all() {
-  config_set('job_scheduler.settings', 'job_scheduler_rebuild_all', TRUE);
+  state_set('job_scheduler_rebuild_all', TRUE);
 }
 
 /**


### PR DESCRIPTION
The config file is constantly switching from TRUE to FALSE - it's noise for managing dev vs prod installations. Issue #4

https://github.com/backdrop-contrib/job_scheduler/issues /4